### PR TITLE
Rescued out reading server config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rvmrc
 .rspec
 .sass-cache
 backups/*.tmp

--- a/lib/milieu.rb
+++ b/lib/milieu.rb
@@ -14,7 +14,7 @@ class Milieu
   end
 
   def self.create
-    contents = read_server_config_file
+    contents = read_server_config_file rescue 'preview'
     case contents
     when 'preview'
       SandboxMilieu.new contents


### PR DESCRIPTION
Trivial little pull to ignore .rvmrc and to rescue out reading of server config file to proceed with rake db:setup.
